### PR TITLE
Pd/pagination and sorting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
+		<dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -1,10 +1,12 @@
 package io.github.dariopipa.warehouse.controllers;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +27,8 @@ import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
 import io.github.dariopipa.warehouse.utils.PaginationUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 @RestController
 @RequestMapping("/api/v1/product-types")
@@ -39,10 +43,20 @@ public class ProductTypeController {
 
 	@GetMapping
 	public PaginatedResponse<ProductTypeResponseDTO> getProductTypes(
-			@RequestParam(defaultValue = "0") int page,
-			@RequestParam(defaultValue = "10") int size) {
+			@RequestParam(defaultValue = "0") @Min(0) int page,
+			@RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+			@RequestParam(defaultValue = "name") String sortBy,
+			@RequestParam(defaultValue = "asc") String direction) {
 
-		Pageable pageable = PageRequest.of(page, size);
+		List<String> allowed = List.of("name", "createdAt");
+		if (!allowed.contains(sortBy)) {
+			throw new IllegalArgumentException(
+					"sortBy must be one of: " + allowed);
+		}
+
+		Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
+		Pageable pageable = PageRequest.of(page, size, sort);
+
 		Page<ProductTypeResponseDTO> paginatedResponse = productTypeService
 				.getCollection(pageable);
 

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,6 +33,7 @@ import jakarta.validation.constraints.Min;
 
 @RestController
 @RequestMapping("/api/v1/product-types")
+@Validated
 @Tag(name = "Products Type")
 public class ProductTypeController {
 
@@ -56,7 +58,6 @@ public class ProductTypeController {
 
 		Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
 		Pageable pageable = PageRequest.of(page, size, sort);
-
 		Page<ProductTypeResponseDTO> paginatedResponse = productTypeService
 				.getCollection(pageable);
 

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -1,13 +1,11 @@
 package io.github.dariopipa.warehouse.controllers;
 
-import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
-import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
-import io.github.dariopipa.warehouse.entities.ProductType;
-import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +14,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
+import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
+import io.github.dariopipa.warehouse.entities.ProductType;
+import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/product-types")
@@ -31,8 +37,15 @@ public class ProductTypeController {
 	}
 
 	@GetMapping("")
-	public List<ProductTypeResponseDTO> getProductTypes() {
-		return this.productTypeService.getCollection();
+	public List<ProductTypeResponseDTO> getProductTypes(
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "10") int size) {
+
+		Pageable pageable = PageRequest.of(page, size);
+		Page<ProductTypeResponseDTO> paginatedResponse = productTypeService
+				.getCollection(pageable);
+
+		return paginatedResponse.getContent();
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -1,7 +1,6 @@
 package io.github.dariopipa.warehouse.controllers;
 
 import java.net.URI;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,9 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
+import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
 import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.ProductType;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
+import io.github.dariopipa.warehouse.utils.PaginationUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -36,8 +37,8 @@ public class ProductTypeController {
 		this.productTypeService = productTypeService;
 	}
 
-	@GetMapping("")
-	public List<ProductTypeResponseDTO> getProductTypes(
+	@GetMapping
+	public PaginatedResponse<ProductTypeResponseDTO> getProductTypes(
 			@RequestParam(defaultValue = "0") int page,
 			@RequestParam(defaultValue = "10") int size) {
 
@@ -45,7 +46,7 @@ public class ProductTypeController {
 		Page<ProductTypeResponseDTO> paginatedResponse = productTypeService
 				.getCollection(pageable);
 
-		return paginatedResponse.getContent();
+		return PaginationUtils.buildPaginatedResponse(paginatedResponse);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
@@ -102,7 +102,6 @@ public class ProductsController {
 
 		Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
 		Pageable pageable = PageRequest.of(page, size, sort);
-
 		Page<ProductGetOneResponseDTO> paginatedResponse = productService
 				.getCollection(pageable);
 

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
@@ -1,7 +1,6 @@
 package io.github.dariopipa.warehouse.controllers;
 
 import java.net.URI;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,7 +22,6 @@ import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
-import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.github.dariopipa.warehouse.utils.PaginationUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
@@ -4,7 +4,6 @@ import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
-import io.github.dariopipa.warehouse.entities.Product;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
@@ -1,15 +1,11 @@
 package io.github.dariopipa.warehouse.controllers;
 
-import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
-import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
-import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
-import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
-import io.github.dariopipa.warehouse.services.interfaces.ProductService;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-
-import java.util.List;
 import java.net.URI;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +14,20 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
+import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
+import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
+import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
+import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
+import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
+import io.github.dariopipa.warehouse.services.interfaces.ProductService;
+import io.github.dariopipa.warehouse.utils.PaginationUtils;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/products")
@@ -76,9 +84,15 @@ public class ProductsController {
 	}
 
 	@GetMapping("")
-	public List<ProductGetOneResponseDTO> getProductCollection() {
+	public PaginatedResponse<ProductGetOneResponseDTO> getProductCollection(
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "10") int size) {
 
-		return this.productService.getCollection();
+		Pageable pageable = PageRequest.of(page, size);
+		Page<ProductGetOneResponseDTO> paginatedResponse = productService
+				.getCollection(pageable);
+
+		return PaginationUtils.buildPaginatedResponse(paginatedResponse);
 	}
 
 }

--- a/src/main/java/io/github/dariopipa/warehouse/dtos/responses/PaginatedResponse.java
+++ b/src/main/java/io/github/dariopipa/warehouse/dtos/responses/PaginatedResponse.java
@@ -1,0 +1,85 @@
+package io.github.dariopipa.warehouse.dtos.responses;
+
+import java.util.List;
+
+public class PaginatedResponse<T> {
+
+	private List<T> data;
+	private int currentPage;
+	private int totalPages;
+	private long totalItems;
+	private int pageSize;
+	private boolean hasNext;
+	private boolean hasPrevious;
+
+	public List<T> getData() {
+		return data;
+	}
+
+	public void setData(List<T> data) {
+		this.data = data;
+	}
+
+	public int getCurrentPage() {
+		return currentPage;
+	}
+
+	public void setCurrentPage(int currentPage) {
+		this.currentPage = currentPage;
+	}
+
+	public int getTotalPages() {
+		return totalPages;
+	}
+
+	public void setTotalPages(int totalPages) {
+		this.totalPages = totalPages;
+	}
+
+	public long getTotalItems() {
+		return totalItems;
+	}
+
+	public void setTotalItems(long totalItems) {
+		this.totalItems = totalItems;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public boolean isHasNext() {
+		return hasNext;
+	}
+
+	public void setHasNext(boolean hasNext) {
+		this.hasNext = hasNext;
+	}
+
+	public boolean isHasPrevious() {
+		return hasPrevious;
+	}
+
+	public void setHasPrevious(boolean hasPrevious) {
+		this.hasPrevious = hasPrevious;
+	}
+
+	public PaginatedResponse() {
+	};
+
+	public PaginatedResponse(List<T> data, int currentPage, int totalPages,
+			long totalItems, int pageSize, boolean hasNext,
+			boolean hasPrevious) {
+		this.data = data;
+		this.currentPage = currentPage;
+		this.totalPages = totalPages;
+		this.totalItems = totalItems;
+		this.pageSize = pageSize;
+		this.hasNext = hasNext;
+		this.hasPrevious = hasPrevious;
+	}
+}

--- a/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductTypeResponseDTO.java
+++ b/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductTypeResponseDTO.java
@@ -1,9 +1,11 @@
 package io.github.dariopipa.warehouse.dtos.responses;
 
+import java.time.Instant;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.time.Instant;
 
 public class ProductTypeResponseDTO {
 

--- a/src/main/java/io/github/dariopipa/warehouse/entities/Product.java
+++ b/src/main/java/io/github/dariopipa/warehouse/entities/Product.java
@@ -1,5 +1,12 @@
 package io.github.dariopipa.warehouse.entities;
 
+import java.time.Instant;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,11 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.Instant;
-import java.util.UUID;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.SoftDelete;
-import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @SoftDelete

--- a/src/main/java/io/github/dariopipa/warehouse/entities/ProductType.java
+++ b/src/main/java/io/github/dariopipa/warehouse/entities/ProductType.java
@@ -1,17 +1,19 @@
 package io.github.dariopipa.warehouse.entities;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.SoftDelete;
-import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @SoftDelete

--- a/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
@@ -1,12 +1,11 @@
 package io.github.dariopipa.warehouse.exceptions;
 
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-
 import java.util.Date;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import jakarta.validation.ConstraintViolationException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -35,6 +38,24 @@ public class GlobalExceptionHandler {
 				"An unexpected error occurred");
 
 		return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Object> handleIllegalArgumentException(
+			IllegalArgumentException ex) {
+		ErrorMessage apiError = new ErrorMessage(HttpStatus.BAD_REQUEST.value(),
+				new Date(), ex.getMessage());
+
+		return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<Object> handleConstraintViolation(
+			ConstraintViolationException ex) {
+		ErrorMessage apiError = new ErrorMessage(HttpStatus.BAD_REQUEST.value(),
+				new Date(), ex.getMessage());
+
+		return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
 	}
 
 }

--- a/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/dariopipa/warehouse/exceptions/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 import jakarta.validation.ConstraintViolationException;
 

--- a/src/main/java/io/github/dariopipa/warehouse/mappers/ProductMapper.java
+++ b/src/main/java/io/github/dariopipa/warehouse/mappers/ProductMapper.java
@@ -1,12 +1,12 @@
 package io.github.dariopipa.warehouse.mappers;
 
+import java.util.UUID;
+
 import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
 import io.github.dariopipa.warehouse.entities.Product;
 import io.github.dariopipa.warehouse.entities.ProductType;
-
-import java.util.UUID;
 
 public class ProductMapper {
 

--- a/src/main/java/io/github/dariopipa/warehouse/repositories/ProductRepository.java
+++ b/src/main/java/io/github/dariopipa/warehouse/repositories/ProductRepository.java
@@ -1,10 +1,11 @@
 package io.github.dariopipa.warehouse.repositories;
 
-import io.github.dariopipa.warehouse.entities.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import io.github.dariopipa.warehouse.entities.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 

--- a/src/main/java/io/github/dariopipa/warehouse/repositories/ProductTypeRepository.java
+++ b/src/main/java/io/github/dariopipa/warehouse/repositories/ProductTypeRepository.java
@@ -1,7 +1,8 @@
 package io.github.dariopipa.warehouse.repositories;
 
-import io.github.dariopipa.warehouse.entities.ProductType;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.github.dariopipa.warehouse.entities.ProductType;
 
 public interface ProductTypeRepository extends JpaRepository<ProductType, Long> {
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
@@ -1,5 +1,9 @@
 package io.github.dariopipa.warehouse.services;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
@@ -13,10 +17,6 @@ import io.github.dariopipa.warehouse.repositories.ProductRepository;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
 import jakarta.transaction.Transactional;
-
-import java.util.List;
-
-import org.springframework.stereotype.Service;
 
 @Service
 public class ProductServiceImpl implements ProductService {

--- a/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
@@ -1,7 +1,5 @@
 package io.github.dariopipa.warehouse.services;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,13 +8,11 @@ import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
-import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.Product;
 import io.github.dariopipa.warehouse.entities.ProductType;
 import io.github.dariopipa.warehouse.exceptions.ConflictException;
 import io.github.dariopipa.warehouse.exceptions.EntityNotFoundException;
 import io.github.dariopipa.warehouse.mappers.ProductMapper;
-import io.github.dariopipa.warehouse.mappers.ProductTypeMapper;
 import io.github.dariopipa.warehouse.repositories.ProductRepository;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;

--- a/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/ProductServiceImpl.java
@@ -2,17 +2,21 @@ package io.github.dariopipa.warehouse.services;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
+import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.Product;
 import io.github.dariopipa.warehouse.entities.ProductType;
 import io.github.dariopipa.warehouse.exceptions.ConflictException;
 import io.github.dariopipa.warehouse.exceptions.EntityNotFoundException;
 import io.github.dariopipa.warehouse.mappers.ProductMapper;
+import io.github.dariopipa.warehouse.mappers.ProductTypeMapper;
 import io.github.dariopipa.warehouse.repositories.ProductRepository;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
@@ -72,10 +76,9 @@ public class ProductServiceImpl implements ProductService {
 	}
 
 	@Override
-	public List<ProductGetOneResponseDTO> getCollection() {
+	public Page<ProductGetOneResponseDTO> getCollection(Pageable pageable) {
+		return productRepository.findAll(pageable).map(ProductMapper::toDto);
 
-		return this.productRepository.findAll().stream()
-				.map(ProductMapper::toDto).toList();
 	}
 
 	@Override
@@ -109,4 +112,5 @@ public class ProductServiceImpl implements ProductService {
 				.orElseThrow(() -> new EntityNotFoundException(
 						"Product not found with id: " + id));
 	}
+
 }

--- a/src/main/java/io/github/dariopipa/warehouse/services/ProductTypeServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/ProductTypeServiceImpl.java
@@ -1,5 +1,11 @@
 package io.github.dariopipa.warehouse.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
 import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.ProductType;
@@ -8,10 +14,6 @@ import io.github.dariopipa.warehouse.exceptions.EntityNotFoundException;
 import io.github.dariopipa.warehouse.mappers.ProductTypeMapper;
 import io.github.dariopipa.warehouse.repositories.ProductTypeRepository;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 @Service
 public class ProductTypeServiceImpl implements ProductTypeService {
@@ -28,10 +30,9 @@ public class ProductTypeServiceImpl implements ProductTypeService {
 	}
 
 	@Override
-	public List<ProductTypeResponseDTO> getCollection() {
-
-		return productTypeRepository.findAll().stream()
-				.map(ProductTypeMapper::toDto).toList();
+	public Page<ProductTypeResponseDTO> getCollection(Pageable pageable) {
+		return productTypeRepository.findAll(pageable)
+				.map(ProductTypeMapper::toDto);
 	}
 
 	@Override

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
@@ -1,10 +1,11 @@
 package io.github.dariopipa.warehouse.services.interfaces;
 
+import java.util.List;
+
 import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
-import java.util.List;
 
 public interface ProductService {
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
@@ -2,6 +2,9 @@ package io.github.dariopipa.warehouse.services.interfaces;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import io.github.dariopipa.warehouse.dtos.requests.CreateProductDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateRequestDTO;
@@ -15,7 +18,7 @@ public interface ProductService {
 
 	void delete(Long id);
 
-	List<ProductGetOneResponseDTO> getCollection();
+	Page<ProductGetOneResponseDTO> getCollection(Pageable pageable);
 
 	ProductGetOneResponseDTO getById(Long id);
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
@@ -1,7 +1,5 @@
 package io.github.dariopipa.warehouse.services.interfaces;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
@@ -1,11 +1,11 @@
 package io.github.dariopipa.warehouse.services.interfaces;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.ProductType;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface ProductTypeService {
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
@@ -3,19 +3,21 @@ package io.github.dariopipa.warehouse.services.interfaces;
 import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
 import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.ProductType;
-import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProductTypeService {
 
-    Long save(ProductTypesDTO productType);
+	Long save(ProductTypesDTO productType);
 
-    void update(Long id, ProductTypesDTO productType);
+	void update(Long id, ProductTypesDTO productType);
 
-    void delete(Long id);
+	void delete(Long id);
 
-    List<ProductTypeResponseDTO> getCollection();
+	Page<ProductTypeResponseDTO> getCollection(Pageable pageable);
 
-    ProductTypeResponseDTO getById(Long id);
+	ProductTypeResponseDTO getById(Long id);
 
-    ProductType getProductType(Long id);
+	ProductType getProductType(Long id);
 }

--- a/src/main/java/io/github/dariopipa/warehouse/utils/PaginationUtils.java
+++ b/src/main/java/io/github/dariopipa/warehouse/utils/PaginationUtils.java
@@ -1,0 +1,29 @@
+package io.github.dariopipa.warehouse.utils;
+
+import org.springframework.data.domain.Page;
+
+import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
+
+public class PaginationUtils {
+
+	private PaginationUtils() {
+
+	}
+
+	public static <T> PaginatedResponse<T> buildPaginatedResponse(
+			Page<T> pageData) {
+
+		PaginatedResponse<T> response = new PaginatedResponse<T>();
+
+		response.setData(pageData.getContent());
+		response.setCurrentPage(pageData.getNumber());
+		response.setTotalPages(pageData.getTotalPages());
+		response.setTotalItems(pageData.getTotalElements());
+		response.setPageSize(pageData.getSize());
+		response.setHasNext(pageData.hasNext());
+		response.setHasPrevious(pageData.hasPrevious());
+
+		return response;
+	}
+
+}


### PR DESCRIPTION
Allowed sort fields  and pagination (business rule):
ProductTypes → name, createdAt
Products → name, createdAt, quantity

If a request param doesn’t match the whitelist, we now return 400 Bad Request (not 500).

Added validation on the query params and a global exception handler to catch the validation errors and return a badrequest