### PR TITLE
feat: add the userid on the user details body so when the jwt gets 

### DIFF
--- a/src/main/java/io/github/dariopipa/warehouse/config/SecurityConfig.java
+++ b/src/main/java/io/github/dariopipa/warehouse/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/auth/register")
 				.hasAnyRole("ADMIN", "MANAGER")
 
+				.requestMatchers("/actuator/**").hasRole("ADMIN")
+
 				// All other endpoints require JWT authentication
 				.anyRequest().authenticated())
 

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ import io.github.dariopipa.warehouse.dtos.requests.ProductTypesDTO;
 import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
 import io.github.dariopipa.warehouse.dtos.responses.ProductTypeResponseDTO;
 import io.github.dariopipa.warehouse.entities.ProductType;
+import io.github.dariopipa.warehouse.entities.User;
 import io.github.dariopipa.warehouse.enums.ProductTypeSortByEnum;
 import io.github.dariopipa.warehouse.enums.SortDirectionEnum;
 import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
@@ -91,11 +93,13 @@ public class ProductTypeController {
 
 	@PostMapping("")
 	public ResponseEntity<Void> createProductTypes(
-			@Valid @RequestBody ProductTypesDTO productType) {
+			@Valid @RequestBody ProductTypesDTO productType,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info("Creating new product type with name: {}",
 				productType.getName());
 
-		Long id = this.productTypeService.save(productType);
+		Long id = this.productTypeService.save(productType,
+				loggedInUser.getId());
 		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
 				.path("/{id}").buildAndExpand(id).toUri();
 
@@ -104,9 +108,10 @@ public class ProductTypeController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteProductTypes(@PathVariable Long id) {
+	public ResponseEntity<Void> deleteProductTypes(@PathVariable Long id,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info("Deleting product type with id: {}", id);
-		this.productTypeService.delete(id);
+		this.productTypeService.delete(id, loggedInUser.getId());
 
 		logger.info("Product type deleted successfully with id: {}", id);
 		return ResponseEntity.noContent().build();
@@ -114,10 +119,11 @@ public class ProductTypeController {
 
 	@PatchMapping("/{id}")
 	public ResponseEntity<ProductType> updateProductTypes(@PathVariable Long id,
-			@Valid @RequestBody ProductTypesDTO productType) {
+			@Valid @RequestBody ProductTypesDTO productType,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info("Updating product type with id: {} and name: {}", id,
 				productType.getName());
-		this.productTypeService.update(id, productType);
+		this.productTypeService.update(id, productType, loggedInUser.getId());
 
 		logger.info("Product type updated successfully with id: {}", id);
 		return ResponseEntity.noContent().build();

--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductsController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +28,7 @@ import io.github.dariopipa.warehouse.dtos.requests.UpdateProductRequestDTO;
 import io.github.dariopipa.warehouse.dtos.requests.UpdateQuantityRequestDTO;
 import io.github.dariopipa.warehouse.dtos.responses.PaginatedResponse;
 import io.github.dariopipa.warehouse.dtos.responses.ProductGetOneResponseDTO;
+import io.github.dariopipa.warehouse.entities.User;
 import io.github.dariopipa.warehouse.services.interfaces.ProductService;
 import io.github.dariopipa.warehouse.utils.PaginationUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,11 +52,12 @@ public class ProductsController {
 
 	@PostMapping("")
 	public ResponseEntity<Void> createProduct(
+			@AuthenticationPrincipal User loggedInUser,
 			@Valid @RequestBody CreateProductDTO requestBody) {
 		logger.info("Creating new product with name: {}",
 				requestBody.getName());
 
-		Long id = this.productService.save(requestBody);
+		Long id = this.productService.save(requestBody, loggedInUser.getId());
 		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
 				.path("/{id}").buildAndExpand(id).toUri();
 
@@ -75,9 +78,10 @@ public class ProductsController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+	public ResponseEntity<Void> deleteProduct(@PathVariable Long id,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info("Deleting product with id: {}", id);
-		this.productService.delete(id);
+		this.productService.delete(id, loggedInUser.getId());
 
 		logger.info("Product deleted successfully with id: {}", id);
 		return ResponseEntity.noContent().build();
@@ -85,10 +89,11 @@ public class ProductsController {
 
 	@PatchMapping("/{id}")
 	public ResponseEntity<Void> updateEntity(@PathVariable Long id,
-			@Valid @RequestBody UpdateProductRequestDTO updateRequestDTO) {
+			@Valid @RequestBody UpdateProductRequestDTO updateRequestDTO,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info("Updating product with id: {} and name: {}", id,
 				updateRequestDTO.getName());
-		this.productService.update(id, updateRequestDTO);
+		this.productService.update(id, updateRequestDTO, loggedInUser.getId());
 
 		logger.info("Product updated successfully with id: {}", id);
 		return ResponseEntity.noContent().build();
@@ -96,13 +101,15 @@ public class ProductsController {
 
 	@PatchMapping("/{id}/quantity")
 	public ResponseEntity<Void> updateProductQuantity(@PathVariable Long id,
-			@Valid @RequestBody UpdateQuantityRequestDTO updateQuantityRequestDTO) {
+			@Valid @RequestBody UpdateQuantityRequestDTO updateQuantityRequestDTO,
+			@AuthenticationPrincipal User loggedInUser) {
 		logger.info(
 				"Updating quantity for product id: {} with operation: {} and quantity: {}",
 				id, updateQuantityRequestDTO.getOperation(),
 				updateQuantityRequestDTO.getQuantity());
 
-		this.productService.updateQuantity(id, updateQuantityRequestDTO);
+		this.productService.updateQuantity(id, updateQuantityRequestDTO,
+				loggedInUser.getId());
 		logger.info("Product quantity updated successfully for id: {}", id);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/io/github/dariopipa/warehouse/entities/User.java
+++ b/src/main/java/io/github/dariopipa/warehouse/entities/User.java
@@ -1,7 +1,13 @@
 package io.github.dariopipa.warehouse.entities;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -21,7 +27,7 @@ import jakarta.validation.constraints.Size;
 @Table(name = "users", uniqueConstraints = {
 		@UniqueConstraint(columnNames = "username"),
 		@UniqueConstraint(columnNames = "email")})
-public class User {
+public class User implements UserDetails {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -92,4 +98,10 @@ public class User {
 		this.roles = roles;
 	}
 
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return roles.stream()
+				.map(role -> new SimpleGrantedAuthority(role.getRole().name()))
+				.collect(Collectors.toSet());
+	}
 }

--- a/src/main/java/io/github/dariopipa/warehouse/exceptions/InvalidRoleException.java
+++ b/src/main/java/io/github/dariopipa/warehouse/exceptions/InvalidRoleException.java
@@ -1,6 +1,8 @@
 package io.github.dariopipa.warehouse.exceptions;
 
 public class InvalidRoleException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
 	public InvalidRoleException(String message) {
 		super(message);
 	}

--- a/src/main/java/io/github/dariopipa/warehouse/exceptions/UserAlreadyExistsException.java
+++ b/src/main/java/io/github/dariopipa/warehouse/exceptions/UserAlreadyExistsException.java
@@ -1,6 +1,8 @@
 package io.github.dariopipa.warehouse.exceptions;
 
 public class UserAlreadyExistsException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
 	public UserAlreadyExistsException(String message) {
 		super(message);
 	}

--- a/src/main/java/io/github/dariopipa/warehouse/security/CustomUserDetailsService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/security/CustomUserDetailsService.java
@@ -1,14 +1,10 @@
 package io.github.dariopipa.warehouse.security;
 
-import java.util.stream.Collectors;
-
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import io.github.dariopipa.warehouse.entities.User;
 import io.github.dariopipa.warehouse.repositories.UserRepository;
 
 @Service
@@ -22,16 +18,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String username)
 			throws UsernameNotFoundException {
-		User user = userRepository.findByUsername(username)
+		return userRepository.findByUsername(username)
 				.orElseThrow(() -> new UsernameNotFoundException(
 						"User not found: " + username));
-
-		return org.springframework.security.core.userdetails.User.builder()
-				.username(user.getUsername()).password(user.getPassword())
-				.authorities(user.getRoles().stream()
-						.map(role -> new SimpleGrantedAuthority(
-								role.getRole().name()))
-						.collect(Collectors.toList()))
-				.build();
 	}
+
 }

--- a/src/main/java/io/github/dariopipa/warehouse/security/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/dariopipa/warehouse/security/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -33,8 +34,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request,
-			HttpServletResponse response, FilterChain filterChain)
+	protected void doFilterInternal(@NonNull HttpServletRequest request,
+			@NonNull HttpServletResponse response,
+			@NonNull FilterChain filterChain)
 			throws ServletException, IOException {
 
 		String authHeader = request.getHeader("Authorization");
@@ -47,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			try {
 				username = jwtUtils.getUsernameFromToken(token);
 			} catch (Exception e) {
-				logger.error("Cannot get username from token: {}",
+				logger.error("Cannot get username or id from token: {}",
 						e.getMessage());
 			}
 		}

--- a/src/main/java/io/github/dariopipa/warehouse/services/AuthServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/AuthServiceImpl.java
@@ -46,9 +46,10 @@ public class AuthServiceImpl implements AuthService {
 		Set<Roles> roles = assignUserRoles(request.getRoles());
 		user.setRoles(roles);
 
+		User savedUser = userRepository.save(user);
 		auditLogger.log(loggedInUser, AuditAction.CREATE, EntityType.USER,
-				user.getId());
-		return userRepository.save(user);
+				savedUser.getId());
+		return savedUser;
 	}
 
 	private Set<Roles> assignUserRoles(Set<String> roleNames) {

--- a/src/main/java/io/github/dariopipa/warehouse/services/AuthServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/AuthServiceImpl.java
@@ -39,13 +39,15 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public User registerNewUser(RegisterUserDTO request) {
+	public User registerNewUser(RegisterUserDTO request, Long loggedInUser) {
 		User user = new User(request.getUsername(), request.getEmail(),
 				passwordEncoder.encode(request.getPassword()));
 
 		Set<Roles> roles = assignUserRoles(request.getRoles());
 		user.setRoles(roles);
 
+		auditLogger.log(loggedInUser, AuditAction.CREATE, EntityType.USER,
+				user.getId());
 		return userRepository.save(user);
 	}
 

--- a/src/main/java/io/github/dariopipa/warehouse/services/ProductTypeServiceImpl.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/ProductTypeServiceImpl.java
@@ -21,11 +21,8 @@ import io.github.dariopipa.warehouse.services.interfaces.ProductTypeService;
 @Service
 public class ProductTypeServiceImpl implements ProductTypeService {
 
-	// REMOVE THE HARD-CODED USER WHEN AUTHENTICATION IS IMPLEMENTED.
 	private final Logger logger = LoggerFactory
 			.getLogger(ProductTypeServiceImpl.class);
-
-	private final Long USER_ID = 1L;
 	private final ProductTypeRepository productTypeRepository;
 	private final AuditLogger auditLogger;
 
@@ -53,7 +50,7 @@ public class ProductTypeServiceImpl implements ProductTypeService {
 	}
 
 	@Override
-	public Long save(ProductTypesDTO dto) {
+	public Long save(ProductTypesDTO dto, Long loggedInUser) {
 		logger.info("Saving new product type: {}", dto.getName());
 
 		if (productTypeRepository.existsByName(dto.getName())) {
@@ -61,18 +58,19 @@ public class ProductTypeServiceImpl implements ProductTypeService {
 			throw new ConflictException("Product type name already exists");
 		}
 
-		ProductType entity = ProductTypeMapper.toEntity(dto, USER_ID);
+		ProductType entity = ProductTypeMapper.toEntity(dto, loggedInUser);
 		ProductType saved = productTypeRepository.save(entity);
 
 		logger.info("Product type saved with id: {}", saved.getId());
 
-		auditLogger.log(USER_ID, AuditAction.CREATE, EntityType.PRODUCT_TYPE,
-				saved.getId());
+		auditLogger.log(loggedInUser, AuditAction.CREATE,
+				EntityType.PRODUCT_TYPE, saved.getId());
 		return saved.getId();
 	}
 
 	@Override
-	public void update(Long id, ProductTypesDTO productType) {
+	public void update(Long id, ProductTypesDTO productType,
+			Long loggedInUser) {
 		logger.info("Updating product type with id: {} and name: {}", id,
 				productType.getName());
 
@@ -88,20 +86,20 @@ public class ProductTypeServiceImpl implements ProductTypeService {
 		this.productTypeRepository.save(existingProductType);
 		logger.info("Product type updated with id: {}", id);
 
-		auditLogger.log(USER_ID, AuditAction.UPDATE, EntityType.PRODUCT_TYPE,
-				id);
+		auditLogger.log(loggedInUser, AuditAction.UPDATE,
+				EntityType.PRODUCT_TYPE, id);
 	}
 
 	@Override
-	public void delete(Long id) {
+	public void delete(Long id, Long loggedInUser) {
 		logger.info("Deleting product type with id: {}", id);
 
 		ProductType productType = getProductType(id);
 		this.productTypeRepository.delete(productType);
 		logger.info("Product type deleted with id: {}", id);
 
-		auditLogger.log(USER_ID, AuditAction.DELETE, EntityType.PRODUCT_TYPE,
-				id);
+		auditLogger.log(loggedInUser, AuditAction.DELETE,
+				EntityType.PRODUCT_TYPE, id);
 	}
 
 	public ProductType getProductType(Long id) {

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/AuthService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/AuthService.java
@@ -5,5 +5,5 @@ import io.github.dariopipa.warehouse.entities.User;
 
 public interface AuthService {
 
-	User registerNewUser(RegisterUserDTO request);
+	User registerNewUser(RegisterUserDTO request, Long loggedInUser);
 }

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductService.java
@@ -11,11 +11,11 @@ import io.github.dariopipa.warehouse.entities.Product;
 
 public interface ProductService {
 
-	Long save(CreateProductDTO product);
+	Long save(CreateProductDTO product,Long loggedInUser);
 
-	void update(Long id, UpdateProductRequestDTO product);
+	void update(Long id, UpdateProductRequestDTO product,Long loggedInUser);
 
-	void delete(Long id);
+	void delete(Long id,Long loggedInUser);
 
 	Page<ProductGetOneResponseDTO> getCollection(Pageable pageable);
 
@@ -24,5 +24,5 @@ public interface ProductService {
 	Product getProductEntityById(Long id);
 
 	void updateQuantity(Long id,
-			UpdateQuantityRequestDTO updateQuantityRequestDTO);
+			UpdateQuantityRequestDTO updateQuantityRequestDTO,Long loggedInUser);
 }

--- a/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
+++ b/src/main/java/io/github/dariopipa/warehouse/services/interfaces/ProductTypeService.java
@@ -9,11 +9,11 @@ import io.github.dariopipa.warehouse.entities.ProductType;
 
 public interface ProductTypeService {
 
-	Long save(ProductTypesDTO productType);
+	Long save(ProductTypesDTO productType, Long loggedInUser);
 
-	void update(Long id, ProductTypesDTO productType);
+	void update(Long id, ProductTypesDTO productType, Long loggedInUser);
 
-	void delete(Long id);
+	void delete(Long id, Long loggedInUser);
 
 	Page<ProductTypeResponseDTO> getCollection(Pageable pageable);
 

--- a/src/main/java/io/github/dariopipa/warehouse/utils/JwtUtils.java
+++ b/src/main/java/io/github/dariopipa/warehouse/utils/JwtUtils.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import io.github.dariopipa.warehouse.entities.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -32,13 +33,14 @@ public class JwtUtils {
 	}
 
 	public String generateJwtToken(Authentication authentication) {
-		String username = authentication.getName();
+		User user = (User) authentication.getPrincipal();
+		Long userId = user.getId();
 
 		Date now = new Date();
 		Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
 
-		return Jwts.builder().subject(username).issuedAt(now)
-				.expiration(expiryDate).signWith(key).compact();
+		return Jwts.builder().subject(user.getUsername()).claim("id", userId)
+				.issuedAt(now).expiration(expiryDate).signWith(key).compact();
 	}
 
 	private Claims parseToken(String token) {


### PR DESCRIPTION
filtered the userid is in every request which can easily allow us to identitify the loggedinuser, updated all the interfaces and services to actaully implement the loggedinuser logic, while removing the hardcoded userid notation, added preauthorize and locked the /actuators path to be accesibile only if the logged in user is an ADMIN