### PR TITLE
Feat: Add hateoas links for products controller and products type con…

### DIFF
--- a/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
+++ b/src/main/java/io/github/dariopipa/warehouse/controllers/ProductTypeController.java
@@ -1,5 +1,8 @@
 package io.github.dariopipa.warehouse.controllers;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -70,6 +73,18 @@ public class ProductTypeController {
 		Page<ProductTypeResponseDTO> paginatedResponse = productTypeService
 				.getCollection(pageable);
 
+		paginatedResponse.forEach(p -> p.add(
+				linkTo(methodOn(ProductTypeController.class)
+						.getProductType(p.getId())).withSelfRel(),
+
+				linkTo(methodOn(ProductTypeController.class)
+						.updateProductTypes(p.getId(), null, null))
+						.withRel("update"),
+
+				linkTo(methodOn(ProductTypeController.class)
+						.deleteProductTypes(p.getId(), null))
+						.withRel("delete")));
+
 		logger.debug(
 				"Product types collection retrieved successfully - total elements: {}",
 				paginatedResponse.getTotalElements());
@@ -84,6 +99,21 @@ public class ProductTypeController {
 
 		ProductTypeResponseDTO productType = this.productTypeService
 				.getById(id);
+
+		productType.add(
+
+				linkTo(methodOn(ProductTypeController.class).getProductType(id))
+						.withSelfRel(),
+
+				linkTo(methodOn(ProductTypeController.class).getProductTypes(0,
+						10, ProductTypeSortByEnum.name, SortDirectionEnum.asc))
+						.withRel("collection"),
+
+				linkTo(methodOn(ProductTypeController.class)
+						.updateProductTypes(id, null, null)).withRel("update"),
+
+				linkTo(methodOn(ProductTypeController.class)
+						.deleteProductTypes(id, null)).withRel("delete"));
 
 		logger.debug("Product type retrieved successfully: {}",
 				productType.getName());

--- a/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductGetOneResponseDTO.java
+++ b/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductGetOneResponseDTO.java
@@ -2,7 +2,11 @@ package io.github.dariopipa.warehouse.dtos.responses;
 
 import java.time.Instant;
 
-public class ProductGetOneResponseDTO {
+import org.springframework.hateoas.RepresentationModel;
+
+public class ProductGetOneResponseDTO
+		extends
+			RepresentationModel<ProductGetOneResponseDTO> {
 
 	private Long id;
 	private String sku;

--- a/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductTypeResponseDTO.java
+++ b/src/main/java/io/github/dariopipa/warehouse/dtos/responses/ProductTypeResponseDTO.java
@@ -2,12 +2,16 @@ package io.github.dariopipa.warehouse.dtos.responses;
 
 import java.time.Instant;
 
+import org.springframework.hateoas.RepresentationModel;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public class ProductTypeResponseDTO {
+public class ProductTypeResponseDTO
+		extends
+			RepresentationModel<ProductTypeResponseDTO> {
 
 	@NotBlank(message = "Id is required")
 	private Long id;


### PR DESCRIPTION
…troller only on the routse that returna  resposne body, e.g the /create endpoint doesnt need them since the hateoas link is in the location header, also fixed the enunm of the collection for the product endpoint to better handle enums